### PR TITLE
Fix typo in job

### DIFF
--- a/kubernetes qa/job.yaml
+++ b/kubernetes qa/job.yaml
@@ -22,7 +22,7 @@ spec:
           - sh
           - "-c"
           - |
-            PGPASSWORD=passwd psql2 -d myapp -U myuser -h $DATABASE_URI  <<'EOF'
+            PGPASSWORD=passwd psql -d myapp -U myuser -h $DATABASE_URI  <<'EOF'
               INSERT INTO client(id,name) 
               VALUES(DEFAULT,'John');
             EOF


### PR DESCRIPTION
## Summary
- correct `psql` command in job example

## Testing
- `yamllint 'kubernetes qa/job.yaml'` *(fails: wrong indentation)*

------
https://chatgpt.com/codex/tasks/task_e_684025834eac832a964cfaadd27c5b9b