### PR TITLE
Fix typo in postgres storage class name

### DIFF
--- a/kubernetes qa/postgres.yaml
+++ b/kubernetes qa/postgres.yaml
@@ -50,7 +50,7 @@ spec:
       name: postgredb
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: managed-standart-ssd-retain
+      storageClassName: managed-standard-ssd-retain
       resources:
         requests:
           storage: 4Gi


### PR DESCRIPTION
## Summary
- correct the storage class name in QA postgres deployment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684026435ef4832a982443a73cde1eae