### PR TITLE
Fix psql invocation in job manifest

### DIFF
--- a/kubernetes qa/job.yaml
+++ b/kubernetes qa/job.yaml
@@ -22,7 +22,7 @@ spec:
           - sh
           - "-c"
           - |
-            PGPASSWORD=passwd psql2 -d myapp -U myuser -h $DATABASE_URI  <<'EOF'
+            PGPASSWORD=passwd psql -d myapp -U myuser -h $DATABASE_URI  <<'EOF'
               INSERT INTO client(id,name) 
               VALUES(DEFAULT,'John');
             EOF


### PR DESCRIPTION
## Summary
- update job.yaml to use `psql` command instead of `psql2`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68402646a5a0832a975f6da4e521ed0c