### PR TITLE
Add manifest validation CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  validate-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
+      - name: Run manifest validation
+        run: ./tests/test_manifests.sh

--- a/tests/test_manifests.sh
+++ b/tests/test_manifests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Find all YAML files in the repository
+mapfile -t files < <(find . -type f -name '*.yaml')
+
+for file in "${files[@]}"; do
+    echo "Checking $file"
+    kubectl apply --dry-run=client -f "$file" >/dev/null
+done
+


### PR DESCRIPTION
## Summary
- add a test script to dry-run kubectl on all YAML manifests
- configure GitHub Actions to run the script on pull requests

## Testing
- `./tests/test_manifests.sh` *(fails: kubectl: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840264a0464832a91d1c58862b66de0